### PR TITLE
Add alternative media control method

### DIFF
--- a/app/src/main/java/com/solderbyte/openfit/MediaController.java
+++ b/app/src/main/java/com/solderbyte/openfit/MediaController.java
@@ -7,7 +7,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.media.AudioManager;
+import android.os.Build;
+import android.os.SystemClock;
 import android.util.Log;
+import android.view.KeyEvent;
 
 public class MediaController {
     private static final String LOG_TAG = "OpenFit:MediaController";
@@ -240,5 +243,42 @@ public class MediaController {
         }
 
         return i;
+    }
+
+    public static void prevTrackAlternative()   {
+        sendFakeMediaKeyEvent(KeyEvent.KEYCODE_MEDIA_PREVIOUS);
+    }
+
+    public static void nextTrackAlternative()   {
+        sendFakeMediaKeyEvent(KeyEvent.KEYCODE_MEDIA_NEXT);
+    }
+
+    public static void playTrackAlternative()   {
+        sendFakeMediaKeyEvent(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE);
+    }
+
+    private static void sendFakeMediaKeyEvent(int keyCode) {
+        long eventTime = SystemClock.uptimeMillis() - 1;
+
+        KeyEvent downEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, keyCode, 0);
+        sendFakeMediaKeyEventImpl(downEvent);
+
+        eventTime++;
+        KeyEvent upEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, keyCode, 0);
+        sendFakeMediaKeyEventImpl(upEvent);
+    }
+
+    private static void sendFakeMediaKeyEventImpl(KeyEvent keyEvent)  {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            // use AudioManager.dispatchKeyEvent() from API 19 (KitKat)
+            // http://stackoverflow.com/questions/19890643/android-4-4-play-default-music-player
+            audioManager.dispatchMediaKeyEvent(keyEvent);
+        }   else    {
+            // use broadcasting fake intent method
+            // http://stackoverflow.com/questions/12925896/android-emulate-send-action-media-button-intent
+            Intent i = new Intent(Intent.ACTION_MEDIA_BUTTON, null);
+            i.putExtra(Intent.EXTRA_KEY_EVENT, keyEvent);
+            context.sendOrderedBroadcast(i, null);
+        }
     }
 }

--- a/app/src/main/java/com/solderbyte/openfit/OpenFitSavedPreferences.java
+++ b/app/src/main/java/com/solderbyte/openfit/OpenFitSavedPreferences.java
@@ -25,6 +25,7 @@ public class OpenFitSavedPreferences {
     public boolean preference_checkbox_sms;
     public boolean preference_checkbox_exercise_gps;
     public boolean preference_checkbox_time;
+    public boolean preference_checkbox_media_control_alternative;
     public String preference_list_weather_value;
     public String preference_list_weather_entry;
     public Set<String> set_packageNames = new LinkedHashSet<String>();
@@ -44,6 +45,7 @@ public class OpenFitSavedPreferences {
         preference_checkbox_sms = preferences.getBoolean("preference_checkbox_sms"+":boolean", PREFS_DEFAULT_BOOL);
         preference_checkbox_exercise_gps = preferences.getBoolean("preference_checkbox_exercise_gps"+":boolean", PREFS_DEFAULT_BOOL);
         preference_checkbox_time = preferences.getBoolean("preference_checkbox_time"+":boolean", PREFS_DEFAULT_BOOL);
+        preference_checkbox_media_control_alternative = preferences.getBoolean("preference_checkbox_media_control_alternative"+":boolean", PREFS_DEFAULT_BOOL);
         preference_list_weather_value = preferences.getString("preference_list_weather_value"+":string", PREFS_DEFAULT);
         preference_list_weather_entry = preferences.getString("preference_list_weather_entry"+":string", PREFS_DEFAULT);
         set_packageNames = preferences.getStringSet("set_packageNames", set_packageNames);

--- a/app/src/main/java/com/solderbyte/openfit/OpenFitService.java
+++ b/app/src/main/java/com/solderbyte/openfit/OpenFitService.java
@@ -840,17 +840,26 @@ public class OpenFitService extends Service {
 
     public void sendMediaPrev() {
         Log.d(LOG_TAG, "Media Prev");
-        sendBroadcast(MediaController.prevTrack(), null);
+        if (!oPrefs.preference_checkbox_media_control_alternative)
+            sendBroadcast(MediaController.prevTrack(), null);
+        else
+            MediaController.prevTrackAlternative();
     }
 
     public void sendMediaNext() {
         Log.d(LOG_TAG, "Media Next");
-        sendBroadcast(MediaController.nextTrack(), null);
+        if (!oPrefs.preference_checkbox_media_control_alternative)
+            sendBroadcast(MediaController.nextTrack(), null);
+        else
+            MediaController.nextTrackAlternative();
     }
 
     public void sendMediaPlay() {
         Log.d(LOG_TAG, "Media Play/Pause");
-        sendBroadcast(MediaController.playTrack(), null);
+        if (!oPrefs.preference_checkbox_media_control_alternative)
+            sendBroadcast(MediaController.playTrack(), null);
+        else
+            MediaController.playTrackAlternative();
     }
 
     public void sendMediaVolume(byte vol, boolean req) {
@@ -1215,9 +1224,15 @@ public class OpenFitService extends Service {
     private BroadcastReceiver mediaReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            String mediaTrack = intent.getStringExtra("mediaTrack");
-            Log.d(LOG_TAG, "Media sending: " + mediaTrack);
-            sendMediaTrack();
+            final String message = intent.getStringExtra(OpenFitIntent.INTENT_EXTRA_MSG);
+            if (message == null || message.equals("")) {
+                String mediaTrack = intent.getStringExtra("mediaTrack");
+                Log.d(LOG_TAG, "Media sending: " + mediaTrack);
+                sendMediaTrack();
+            }   else if (message.equals(OpenFitIntent.ACTION_MEDIA_METHOD_CHANGE))  {
+                final String data = intent.getStringExtra(OpenFitIntent.INTENT_EXTRA_DATA);
+                oPrefs.preference_checkbox_media_control_alternative = data.equals(OpenFitIntent.ACTION_TRUE);
+            }
         }
     };
 

--- a/app/src/main/java/com/solderbyte/openfit/ui/OpenFitActivity.java
+++ b/app/src/main/java/com/solderbyte/openfit/ui/OpenFitActivity.java
@@ -198,6 +198,7 @@ public class OpenFitActivity extends Activity {
         private static CheckBoxPreference preference_checkbox_sms;
         private static CheckBoxPreference preference_checkbox_time;
         private static CheckBoxPreference preference_checkbox_googlefit;
+        private static CheckBoxPreference preference_checkbox_media_control_alternative;
         private static ListPreference preference_list_weather;
         private static ListPreference preference_list_devices;
         private static Preference preference_scan;
@@ -450,6 +451,23 @@ public class OpenFitActivity extends Activity {
                     else {
                         sendIntent(OpenFitIntent.INTENT_SERVICE_BT, OpenFitIntent.ACTION_GPS, OpenFitIntent.ACTION_FALSE);
                         oPrefs.saveBoolean("preference_checkbox_exercise_gps", false);
+                        return true;
+                    }
+                }
+            });
+
+            preference_checkbox_media_control_alternative = (CheckBoxPreference) getPreferenceManager().findPreference("preference_checkbox_media_control_alternative");
+            preference_checkbox_media_control_alternative.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    if((Boolean) newValue) {
+                        sendIntent(OpenFitIntent.INTENT_SERVICE_MEDIA, OpenFitIntent.ACTION_MEDIA_METHOD_CHANGE, OpenFitIntent.ACTION_TRUE);
+                        oPrefs.saveBoolean("preference_checkbox_media_control_alternative", true);
+                        return true;
+                    }
+                    else {
+                        sendIntent(OpenFitIntent.INTENT_SERVICE_MEDIA, OpenFitIntent.ACTION_MEDIA_METHOD_CHANGE, OpenFitIntent.ACTION_FALSE);
+                        oPrefs.saveBoolean("preference_checkbox_media_control_alternative", false);
                         return true;
                     }
                 }

--- a/app/src/main/java/com/solderbyte/openfit/util/OpenFitIntent.java
+++ b/app/src/main/java/com/solderbyte/openfit/util/OpenFitIntent.java
@@ -51,6 +51,7 @@ public class OpenFitIntent {
     public static final String ACTION_TIME = "time";
     public static final String ACTION_WEATHER = "weather";
     public static final String ACTION_FITNESS = "fitness";
+    public static final String ACTION_MEDIA_METHOD_CHANGE = "mediaMethodChange";
 
     public static final String DEFAULT = "DEFAULT";
     public static final String NONE = "none";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,10 @@
     <string name="preference_purchase_summary">Purchase Premium features. Please see help for more information.</string>
     <string name="preference_purchased_summary">Thank you for purchasing Open Fit Premium</string>
     <string name="preference_applications_summary">No applications added. Click the + icon at the top menu to add an application. Make sure Notification Access is Enabled, otherwise notifcations will not work</string>
+    <string name="preference_category_misc_title">Misc</string>
+    <string name="preference_checkbox_media_control_alternative_title">Alternative Media Control</string>
+    <string name="preference_checkbox_media_control_alternative_on">Use Media Button Dispatch Method</string>
+    <string name="preference_checkbox_media_control_alternative_off">Use Alternative Method if Media Control not works</string>
     <string name="toast_bluetooth_enable">Enabling&#8230;</string>
     <string name="toast_bluetooth_scan">Scanning&#8230;</string>
     <string name="toast_bluetooth_scan_complete">Scanning complete. Please select device</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -98,4 +98,15 @@
         android:icon="@drawable/open_donate"
         android:title="@string/preference_purchase_title"
         android:summary="@string/preference_purchase_summary"/>
+
+    <PreferenceCategory
+        android:title="@string/preference_category_misc_title"
+        android:key="preference_category_misc">
+        <CheckBoxPreference
+            android:key="preference_checkbox_media_control_alternative"
+            android:title="@string/preference_checkbox_media_control_alternative_title"
+            android:summaryOn="@string/preference_checkbox_media_control_alternative_on"
+            android:summaryOff="@string/preference_checkbox_media_control_alternative_off"
+            android:defaultValue="false" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Hi!

Please consider implementing alternative media control method for music apps not supporting "com.android.music.musicservicecommand" intent.

There is an alternative media control method using [AudioManager.dispatchMediaKeyEvent()](https://developer.android.com/reference/android/media/AudioManager.html#dispatchMediaKeyEvent%28android.view.KeyEvent%29) method which can emulate media button (e.g. Bluetooth headset, or else) click.

The essence of new controller code is just in **MediaController.java:248-283**. Above mentioned method is used for API 19+(KitKat). For the API version less than 19, which did not consider security issue, we can freely broadcast fake media button intent (although I didn't test).

I believe that this method covers current "musicservicecommand" use case. But because I'm unable to test over every possible use case, so I've decided to implement an option to choose whether to use alternative media control method. Codes other than MediaController.java are for implementing that.

With these code, **Google Play Music** app, **LG Stock Music** app, and **NaverMusic/BugsMusic** app (paid streaming music service in South Korea) works without problem in LGE G Pro 2 device (Android 5.0.1). I wanted to test Spotify app, but failed because it does not work in South Korea and I failed to use VPN.

Because I'm not good at implementing Android App. or English skill, feel free to reject my code......
Thank you.
